### PR TITLE
Apk duplicate os package annotations

### DIFF
--- a/annotator/osduplicate/apk/apk.go
+++ b/annotator/osduplicate/apk/apk.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apk implements an annotator for language packages that have already been found in
+// APK OS packages.
+package apk
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/google/osv-scalibr/annotator"
+	"github.com/google/osv-scalibr/annotator/osduplicate"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/vex"
+	"github.com/google/osv-scalibr/plugin"
+)
+
+const (
+	// Name of the Annotator.
+	Name           = "vex/os-duplicate/apk"
+	apkInstalledDB = "lib/apk/db/installed"
+)
+
+// Annotator adds annotations to language packages that have already been found in APK OS packages.
+type Annotator struct{}
+
+// New returns a new Annotator.
+func New() annotator.Annotator { return &Annotator{} }
+
+// Name of the annotator.
+func (Annotator) Name() string { return Name }
+
+// Version of the annotator.
+func (Annotator) Version() int { return 0 }
+
+// Requirements of the annotator.
+func (Annotator) Requirements() *plugin.Capabilities {
+	return &plugin.Capabilities{OS: plugin.OSLinux}
+}
+
+// parseSingleApkRecord reads from the scanner a single record,
+// returns nil, nil when scanner ends.
+func parseSingleApkRecord(scanner *bufio.Scanner) (map[string]string, error) {
+	// There is currently 26 keys defined here (Under "Installed Database V2"):
+	// https://wiki.alpinelinux.org/wiki/Apk_spec
+	group := map[string]string{}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line != "" {
+			key, val, found := strings.Cut(line, ":")
+
+			if !found {
+				return nil, fmt.Errorf("invalid line: %q", line)
+			}
+
+			group[key] = val
+			continue
+		}
+
+		// check both that line is empty and we have filled out data in group
+		// this avoids double empty lines returning early
+		if line == "" && len(group) > 0 {
+			// scanner.Err() could only be non nil when Scan() returns false
+			// so we can return nil directly here
+			return group, nil
+		}
+	}
+
+	return group, scanner.Err()
+}
+
+// Annotate adds annotations to language packages that have already been found in APK OS packages.
+func (a *Annotator) Annotate(ctx context.Context, input *annotator.ScanInput, results *inventory.Inventory) error {
+	locationToPKGs := osduplicate.BuildLocationToPKGsMap(results)
+
+	f, err := input.ScanRoot.FS.Open(apkInstalledDB)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	errs := []error{}
+
+	scanner := bufio.NewScanner(f)
+	for {
+		// Return if canceled or exceeding deadline.
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, fmt.Errorf("%s halted at %q because of context error: %w", a.Name(), input.ScanRoot.Path, err))
+			break
+		}
+
+		record, err := parseSingleApkRecord(scanner)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("error while parsing apk status file %q: %w", input.ScanRoot.Path, err))
+			return errors.Join(errs...)
+		}
+
+		if len(record) == 0 {
+			break
+		}
+
+		folder := record["F"]
+		filename := record["R"]
+
+		// if the filePath is not retrievable continue to the next package
+		if folder == "" || filename == "" {
+			continue
+		}
+
+		filePath := path.Join(folder, filename)
+
+		if pkgs, ok := locationToPKGs[filePath]; ok {
+			for _, pkg := range pkgs {
+				pkg.ExploitabilitySignals = append(pkg.ExploitabilitySignals, &vex.PackageExploitabilitySignal{
+					Plugin:          Name,
+					Justification:   vex.ComponentNotPresent,
+					MatchesAllVulns: true,
+				})
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}

--- a/annotator/osduplicate/apk/apk_test.go
+++ b/annotator/osduplicate/apk/apk_test.go
@@ -1,0 +1,167 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apk_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/go-cpy/cpy"
+	"github.com/google/osv-scalibr/annotator"
+	"github.com/google/osv-scalibr/annotator/osduplicate/apk"
+	"github.com/google/osv-scalibr/extractor"
+	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/inventory"
+	"github.com/google/osv-scalibr/inventory/vex"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestAnnotate(t *testing.T) {
+	cancelledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	copier := cpy.New(
+		cpy.Func(proto.Clone),
+		cpy.IgnoreAllUnexported(),
+	)
+
+	tests := []struct {
+		desc     string
+		apkDB    string
+		packages []*extractor.Package
+		//nolint:containedctx
+		ctx          context.Context
+		wantErr      error
+		wantPackages []*extractor.Package
+	}{
+		{
+			desc:  "empty_db",
+			apkDB: "testdata/empty",
+			packages: []*extractor.Package{
+				{
+					Name:      "libstdc++",
+					Locations: []string{"usr/lib/libstdc++.so.6.0.33"},
+				},
+			},
+			wantPackages: []*extractor.Package{
+				{
+					Name:      "libstdc++",
+					Locations: []string{"usr/lib/libstdc++.so.6.0.33"},
+				},
+			},
+		},
+		{
+			desc:  "some_pkgs_found_in_db",
+			apkDB: "testdata/some",
+			packages: []*extractor.Package{
+				{
+					Name:      "libstdc++",
+					Locations: []string{"usr/lib/libstdc++.so.6.0.33"},
+				},
+				{
+					Name:      "not-in-db",
+					Locations: []string{"path/not/in/db"},
+				},
+			},
+			wantPackages: []*extractor.Package{
+				{
+					Name:      "libstdc++",
+					Locations: []string{"usr/lib/libstdc++.so.6.0.33"},
+					ExploitabilitySignals: []*vex.PackageExploitabilitySignal{&vex.PackageExploitabilitySignal{
+						Plugin:          apk.Name,
+						Justification:   vex.ComponentNotPresent,
+						MatchesAllVulns: true,
+					}},
+				},
+				{
+					Name:      "not-in-db",
+					Locations: []string{"path/not/in/db"},
+				},
+			},
+		},
+		{
+			desc:  "ctx_cancelled",
+			ctx:   cancelledContext,
+			apkDB: "testdata/some",
+			packages: []*extractor.Package{
+				{
+					Name:      "libstdc++",
+					Locations: []string{"usr/lib/libstdc++.so.6.0.33"},
+				},
+			},
+			wantPackages: []*extractor.Package{
+				{
+					Name:      "libstdc++",
+					Locations: []string{"usr/lib/libstdc++.so.6.0.33"},
+					// No annotations
+				},
+			},
+			wantErr: cmpopts.AnyError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if tt.ctx == nil {
+				tt.ctx = context.Background()
+			}
+
+			tmpPath := setupApkDB(t, tt.apkDB)
+			input := &annotator.ScanInput{
+				ScanRoot: scalibrfs.RealFSScanRoot(tmpPath),
+			}
+
+			// Deep copy the packages to avoid modifying the original inventory that is used in other tests.
+			packages := copier.Copy(tt.packages).([]*extractor.Package)
+			inv := &inventory.Inventory{Packages: packages}
+
+			err := apk.New().Annotate(tt.ctx, input, inv)
+			if !cmp.Equal(tt.wantErr, err, cmpopts.EquateErrors()) {
+				t.Fatalf("Annotate(%v) error: %v, want %v", tt.packages, err, tt.wantErr)
+			}
+
+			want := &inventory.Inventory{Packages: tt.wantPackages}
+			if diff := cmp.Diff(want, inv); diff != "" {
+				t.Errorf("Annotate(%v): unexpected diff (-want +got): %v", tt.packages, diff)
+			}
+		})
+	}
+}
+
+// Sets up the apk db
+func setupApkDB(t *testing.T, file string) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbFolder := filepath.Join(dir, "lib/apk/db/")
+	if err := os.MkdirAll(dbFolder, 0777); err != nil {
+		t.Fatalf("error creating directory %q: %v", dbFolder, err)
+	}
+
+	content, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("Error reading content file %q: %v", content, err)
+	}
+
+	dbFile := filepath.Join(dbFolder, "installed")
+	if err := os.WriteFile(dbFile, content, 0644); err != nil {
+		t.Fatalf("Error creating file %q: %v", dbFile, err)
+	}
+
+	return dir
+}

--- a/annotator/osduplicate/apk/testdata/some
+++ b/annotator/osduplicate/apk/testdata/some
@@ -1,0 +1,40 @@
+C:Q1smIZUQjMDPDDEMJOQmqXSfiZuUY=
+P:python3-pyc
+V:3.12.11-r0
+A:aarch64
+S:1299
+I:0
+T:High-level scripting language (install .pyc cache files)
+U:https://www.python.org/
+L:PSF-2.0
+o:python3
+m:Natanael Copa <ncopa@alpinelinux.org>
+t:1749030947
+c:9efc8af3c3c914e6335b7d13bb2f49a4c7b5826c
+D:python3-pycache-pyc0=3.12.11-r0 pyc
+i:python3=3.12.11-r0
+
+C:Q1m+yT9cA6w+D55pj502hftj3qOVY=
+P:libstdc++
+V:14.2.0-r6
+A:aarch64
+S:906209
+I:2754992
+T:GNU C++ standard runtime library
+U:https://gcc.gnu.org
+L:GPL-2.0-or-later AND LGPL-2.1-or-later
+o:gcc
+m:Ariadne Conill <ariadne@dereferenced.org>
+t:1746799641
+c:fbf60319be3bbaf6dd32ef55cc6fb7189e05c266
+D:so:libc.musl-aarch64.so.1 so:libgcc_s.so.1
+p:so:libstdc++.so.6=6.0.33
+r:libstdc++ binutils
+F:usr
+F:usr/lib
+R:libstdc++.so.6
+a:0:0:777
+Z:Q1zXyCP/4899Z2UkECzKdgCnrdenI=
+R:libstdc++.so.6.0.33
+a:0:0:755
+Z:Q184DyzCylUa5WvMjPTw5XlThxdPA=


### PR DESCRIPTION
This PR adds a `PackageExploitabilitySignal` entry to packages found by language extractor which were already found by OS extractors.