### PR TITLE
Veles secrets GitHub app user to server token

### DIFF
--- a/veles/secrets/github/appusertoservertoken/detector.go
+++ b/veles/secrets/github/appusertoservertoken/detector.go
@@ -1,0 +1,15 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appusertoservertoken

--- a/veles/secrets/github/appusertoservertoken/detector.go
+++ b/veles/secrets/github/appusertoservertoken/detector.go
@@ -13,3 +13,40 @@
 // limitations under the License.
 
 package appusertoservertoken
+
+import (
+	"regexp"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+const tokenMaxLen = 40
+
+var tokenPattern = regexp.MustCompile(`ghu_[A-Za-z0-9]{36}`)
+
+// Detector detects Github app refresh tokens
+type Detector struct{}
+
+// NewDetector returns a new Veles Detector that finds Github app refresh tokens
+func NewDetector() veles.Detector {
+	return Detector{}
+}
+
+// Detect detects Github app refresh tokens
+func (d Detector) Detect(data []byte) ([]veles.Secret, []int) {
+	secrets := []veles.Secret{}
+	positions := []int{}
+	for _, m := range tokenPattern.FindAllIndex(data, -1) {
+		l, r := m[0], m[1]
+		token := string(data[l:r])
+		// TODO: add checksum validation
+		secrets = append(secrets, GithubAppUserToServerToken{Token: token})
+		positions = append(positions, l)
+	}
+	return secrets, positions
+}
+
+// MaxSecretLen return the Github App refresh token max length
+func (d Detector) MaxSecretLen() uint32 {
+	return tokenMaxLen
+}

--- a/veles/secrets/github/appusertoservertoken/detector_test.go
+++ b/veles/secrets/github/appusertoservertoken/detector_test.go
@@ -10,18 +10,146 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.// Copyright 2025 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
 // limitations under the License.
 
 package appusertoservertoken_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/github/appusertoservertoken"
+)
+
+// Note: Github tokens are encoded using `` + `` to bypass github security checks
+
+const (
+	testKey        = `gh` + `u_aGgfQsQ52sImE9zwWxKcjt2nhESfYG1U2FhX`
+	anotherTestKey = `gh` + `u_QoXdtrSAaW5sNsCFtHv8cK0ImbQxn11nVkQT`
+)
+
+// TestDetector_truePositives tests for cases where we know the Detector
+// will find a Github app refresh tokens.
+func TestDetector_truePositives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{appusertoservertoken.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "simple matching string",
+		input: testKey,
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+		},
+	}, {
+		name:  "simple matching string another key",
+		input: anotherTestKey,
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: anotherTestKey},
+		},
+	}, {
+		name:  "match at end of string",
+		input: `API_TOKEN=` + testKey,
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+		},
+	}, {
+		name:  "match in middle of string",
+		input: `API_TOKEN="` + testKey + `"`,
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+		},
+	}, {
+		name:  "multiple matches",
+		input: testKey + testKey + testKey,
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+		},
+	}, {
+		name:  "multiple distinct matches",
+		input: testKey + "\n" + anotherTestKey,
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+			appusertoservertoken.GithubAppUserToServerToken{Token: anotherTestKey},
+		},
+	}, {
+		name: "larger input containing key",
+		input: fmt.Sprintf(`
+:test_api_key: do-test
+:API_TOKEN: %s
+		`, testKey),
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+		},
+	}, {
+		name:  "potential match longer than max key length",
+		input: testKey + `extra`,
+		want: []veles.Secret{
+			appusertoservertoken.GithubAppUserToServerToken{Token: testKey},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDetector_trueNegatives tests for cases where we know the Detector
+// will not find a Github app refresh tokens.
+func TestDetector_trueNegatives(t *testing.T) {
+	engine, err := veles.NewDetectionEngine([]veles.Detector{appusertoservertoken.NewDetector()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name  string
+		input string
+		want  []veles.Secret
+	}{{
+		name:  "empty input",
+		input: "",
+	}, {
+		name:  "short key should not match",
+		input: testKey[:len(testKey)-1],
+	}, {
+		name:  "invalid character in key should not match",
+		input: `gh` + `u_aGgfQsQ52sImE9zwWxKcjt2nhESf^G1U2FhX`,
+	}, {
+		name:  "incorrect prefix should not match",
+		input: `Eop_v1_OWOCPzqKuy3J4w53QpkLfffjBUJSh5yLnFHj7wiyR0NDadVOcykNkoqhoYYXM1yy2sOpAu0lG8fw`,
+	}, {
+		name:  "bad checksum should not match",
+		input: `gh` + `u_aGgfQsQ52sImE91wWxKcjt2nhESfYG1U2FhX`,
+	}, {
+		name:  "prefix missing dash should not match",
+		input: `gh` + `uaGgfQsQ52sImE91wWxKcjt2nhESfYG1U2FhX`,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := engine.Detect(t.Context(), strings.NewReader(tc.input))
+			if err != nil {
+				t.Errorf("Detect() error: %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Detect() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/veles/secrets/github/appusertoservertoken/detector_test.go
+++ b/veles/secrets/github/appusertoservertoken/detector_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appusertoservertoken_test

--- a/veles/secrets/github/appusertoservertoken/usertoservertoken.go
+++ b/veles/secrets/github/appusertoservertoken/usertoservertoken.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package appusertoservertoken contains a Veles Secret type, a Detector, and a Validator for
+// User to Server token detection.
+package appusertoservertoken
+
+// appusertoservertoken contains a user to server token
+//
+// A Github App User to Server token is a temporary, secure credential that allows a GitHub App
+// to perform actions on the platform on behalf of a user
+type appusertoservertoken struct {
+	Token string
+}

--- a/veles/secrets/github/appusertoservertoken/usertoservertoken.go
+++ b/veles/secrets/github/appusertoservertoken/usertoservertoken.go
@@ -16,10 +16,10 @@
 // User to Server token detection.
 package appusertoservertoken
 
-// appusertoservertoken contains a user to server token
+// GithubAppUserToServerToken contains a user to server token
 //
 // A Github App User to Server token is a temporary, secure credential that allows a GitHub App
 // to perform actions on the platform on behalf of a user
-type appusertoservertoken struct {
+type GithubAppUserToServerToken struct {
 	Token string
 }

--- a/veles/secrets/github/appusertoservertoken/validator.go
+++ b/veles/secrets/github/appusertoservertoken/validator.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appusertoservertoken
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/osv-scalibr/veles"
+)
+
+// Validator validates Github app User to Server token via the Github API endpoint.
+type Validator struct {
+	httpC *http.Client
+}
+
+// ValidatorOption configures a Validator when creating it via NewValidator.
+type ValidatorOption func(*Validator)
+
+// WithClient configures the http.Client that the Validator uses.
+//
+// By default, it uses http.DefaultClient.
+func WithClient(c *http.Client) ValidatorOption {
+	return func(v *Validator) {
+		v.httpC = c
+	}
+}
+
+// NewValidator creates a new Validator with the given ValidatorOptions.
+func NewValidator(opts ...ValidatorOption) *Validator {
+	v := &Validator{
+		httpC: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+// Validate checks whether the given Github app User to Server token is valid.
+func (v *Validator) Validate(ctx context.Context, key GithubAppUserToServerToken) (veles.ValidationStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"https://api.github.com/user", nil)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("unable to create HTTP request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+key.Token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	res, err := v.httpC.Do(req)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("HTTP GET failed: %w", err)
+	}
+	defer res.Body.Close()
+	_, err = io.ReadAll(res.Body)
+	if err != nil {
+		return veles.ValidationFailed, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return veles.ValidationValid, nil
+	case http.StatusUnauthorized:
+		return veles.ValidationInvalid, nil
+	default:
+		return veles.ValidationFailed, nil
+	}
+}

--- a/veles/secrets/github/appusertoservertoken/validator_test.go
+++ b/veles/secrets/github/appusertoservertoken/validator_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appusertoservertoken_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv-scalibr/veles"
+	"github.com/google/osv-scalibr/veles/secrets/github/appusertoservertoken"
+)
+
+const validatorTestKey = `gh` + `u_aGgfQsQ52sImE9zwWxKcjt2nhESfYG1U2FhX`
+
+// mockTransport redirects requests to the test server
+type mockTransport struct {
+	testServer *httptest.Server
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the original URL with our test server URL
+	if req.URL.Host == "api.github.com" {
+		testURL, _ := url.Parse(m.testServer.URL)
+		req.URL.Scheme = testURL.Scheme
+		req.URL.Host = testURL.Host
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// mockGithubServer creates a mock Github API server for testing
+func mockGithubServer(t *testing.T, expectedKey string, code int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if it's a GET request to the expected endpoint
+		if r.Method != http.MethodGet || r.URL.Path != "/user" {
+			t.Errorf("unexpected request: %s %s, expected: GET /v2/account", r.Method, r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		if code != http.StatusOK {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
+			return
+		}
+
+		// Check Authorization header
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer "+expectedKey {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Set response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestValidator(t *testing.T) {
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slowServer.Close()
+
+	shortCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	cases := []struct {
+		name    string
+		token   string
+		server  *httptest.Server
+		want    veles.ValidationStatus
+		wantErr error
+		//nolint:containedctx
+		ctx context.Context
+	}{
+		{
+			name:    "slow_server",
+			ctx:     shortCtx,
+			server:  slowServer,
+			want:    veles.ValidationFailed,
+			wantErr: cmpopts.AnyError,
+		},
+		{
+			name:   "valid_key",
+			token:  validatorTestKey,
+			server: mockGithubServer(t, validatorTestKey, http.StatusOK),
+			want:   veles.ValidationValid,
+		},
+		{
+			name:   "invalid_key_unauthorized",
+			token:  "random_string",
+			server: mockGithubServer(t, validatorTestKey, http.StatusUnauthorized),
+			want:   veles.ValidationInvalid,
+		},
+		{
+			name:   "server_error",
+			server: mockGithubServer(t, validatorTestKey, http.StatusInternalServerError),
+			want:   veles.ValidationFailed,
+		},
+		{
+			name:   "bad_gateway",
+			server: mockGithubServer(t, validatorTestKey, http.StatusBadGateway),
+			want:   veles.ValidationFailed,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.ctx == nil {
+				tt.ctx = t.Context() //nolint:fatcontext
+			}
+
+			// Create a client with custom transport
+			client := &http.Client{
+				Transport: &mockTransport{testServer: tt.server},
+			}
+
+			// Create a validator with a mock client
+			validator := appusertoservertoken.NewValidator(
+				appusertoservertoken.WithClient(client),
+			)
+
+			// Create a test key
+			key := appusertoservertoken.GithubAppUserToServerToken{Token: tt.token}
+
+			// Test validation
+			got, err := validator.Validate(tt.ctx, key)
+
+			if !cmp.Equal(tt.wantErr, err, cmpopts.EquateErrors()) {
+				t.Fatalf("Validate() error: %v, want %v", err, tt.wantErr)
+			}
+
+			if tt.want != got {
+				t.Errorf("Validate(): got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pr contains the implementation of a Github App `user to server` token detector.

ref: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app

TODO:

- [ ] add `NewDetector`
- [ ] add `NewValidator`
- [ ] proto conversion logic