### PR TITLE
Fix issues encountered during osduplicate testbed testing

### DIFF
--- a/annotator/osduplicate/apk/apk.go
+++ b/annotator/osduplicate/apk/apk.go
@@ -87,21 +87,25 @@ func (a *Annotator) Annotate(ctx context.Context, input *annotator.ScanInput, re
 		}
 
 		record := scanner.Record()
-
 		folder := record["F"]
 		filename := record["R"]
+		pkgName := record["P"]
+		pkgVersion := record["V"]
 
 		// if the filePath is not retrievable continue to the next package
-		if folder == "" || filename == "" {
+		if folder == "" || filename == "" || pkgName == "" || pkgVersion == "" {
+			continue
+		}
+
+		// Do not add duplication annotation on packages which are from non-main repos
+		// since vuln matching can happen only on packages hosted on main repos
+		if !outOfSyncCache && !mainOSPackages.contains(pkgName, pkgVersion) {
 			continue
 		}
 
 		filePath := path.Join(folder, filename)
 
 		for _, pkg := range locationToPKGs[filePath] {
-			if !outOfSyncCache && !mainOSPackages.contains(pkg) {
-				continue
-			}
 			pkg.ExploitabilitySignals = append(pkg.ExploitabilitySignals, &vex.PackageExploitabilitySignal{
 				Plugin:          Name,
 				Justification:   vex.ComponentNotPresent,

--- a/annotator/osduplicate/apk/cache.go
+++ b/annotator/osduplicate/apk/cache.go
@@ -186,6 +186,8 @@ func extractRepositoryIndex(root *fs.ScanRoot, filePath string, cache *mainOSPac
 		}
 
 		scanner := apkutil.NewScanner(tr)
+		scanner.DiscardLongLines()
+
 		for scanner.Scan() {
 			record := scanner.Record()
 			pkgName, ok := record["P"]

--- a/annotator/osduplicate/apk/cache.go
+++ b/annotator/osduplicate/apk/cache.go
@@ -29,7 +29,6 @@ import (
 
 	iofs "io/fs"
 
-	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/extractor/filesystem/os/apk/apkutil"
 	"github.com/google/osv-scalibr/fs"
 )
@@ -55,8 +54,8 @@ type mainOSPackages struct {
 }
 
 // contains returns true if a package found in main OS repo index
-func (a *mainOSPackages) contains(pkg *extractor.Package) bool {
-	_, exists := a.value[key(pkg.Name, pkg.Version)]
+func (a *mainOSPackages) contains(pkgName, pkgVersion string) bool {
+	_, exists := a.value[key(pkgName, pkgVersion)]
 	return exists
 }
 

--- a/annotator/osduplicate/dpkg/aptcache.go
+++ b/annotator/osduplicate/dpkg/aptcache.go
@@ -103,29 +103,9 @@ func parseAptList(fileSystem iofs.FS, path string, cache *aptCache) error {
 	}
 	defer reader.Close()
 
-	bufReader := bufio.NewReader(reader)
-	skippingLongLine := false
-	for {
-		line, isPrefix, err := bufReader.ReadLine()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return err
-		}
-
-		// if the line is too long to fit in the buffer skip it
-		if isPrefix {
-			skippingLongLine = true
-			continue
-		}
-
-		// finish consuming the line (until the first isPrefix is false)
-		if skippingLongLine && !isPrefix {
-			skippingLongLine = false
-			continue
-		}
-
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Bytes()
 		// Check if the start of this line contains a package name
 		if after, ok := bytes.CutPrefix(line, []byte("Package: ")); ok {
 			cache.value[string(after)] = struct{}{}

--- a/annotator/osduplicate/dpkg/aptcache.go
+++ b/annotator/osduplicate/dpkg/aptcache.go
@@ -103,14 +103,36 @@ func parseAptList(fileSystem iofs.FS, path string, cache *aptCache) error {
 	}
 	defer reader.Close()
 
-	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		if after, ok := strings.CutPrefix(scanner.Text(), "Package: "); ok {
+	// Replace Scanner with Reader
+	bufReader := bufio.NewReader(reader)
+
+	for {
+		line, isPrefix, err := bufReader.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		// Check if the start of this line contains a package name
+		if after, ok := strings.CutPrefix(string(line), "Package: "); ok {
 			cache.value[after] = struct{}{}
+		}
+
+		// If the line was too long for the buffer, drain the remainder of it.
+		for isPrefix {
+			_, isPrefix, err = bufReader.ReadLine()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return err
+			}
 		}
 	}
 
-	return scanner.Err()
+	return nil
 }
 
 // readerFromExtension returns an io.ReadCloser depending on the file extension

--- a/annotator/osduplicate/dpkg/aptcache.go
+++ b/annotator/osduplicate/dpkg/aptcache.go
@@ -112,7 +112,7 @@ func parseAptList(fileSystem iofs.FS, path string, cache *aptCache) error {
 		}
 	}
 
-	return nil
+	return scanner.Err()
 }
 
 // readerFromExtension returns an io.ReadCloser depending on the file extension

--- a/annotator/osduplicate/dpkg/aptcache.go
+++ b/annotator/osduplicate/dpkg/aptcache.go
@@ -25,7 +25,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/osv-scalibr/extractor"
 	"github.com/google/osv-scalibr/fs"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -42,8 +41,8 @@ type aptCache struct {
 }
 
 // isFromMainOSRepo returns true if a package found in main OS repo index
-func (a *aptCache) isFromMainOSRepo(pkg *extractor.Package) bool {
-	_, exists := a.value[pkg.Name]
+func (a *aptCache) isFromMainOSRepo(pkgName string) bool {
+	_, exists := a.value[pkgName]
 	return exists
 }
 

--- a/annotator/osduplicate/dpkg/aptcache.go
+++ b/annotator/osduplicate/dpkg/aptcache.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/google/osv-scalibr/common/io/discard"
 	"github.com/google/osv-scalibr/fs"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -104,6 +105,7 @@ func parseAptList(fileSystem iofs.FS, path string, cache *aptCache) error {
 	defer reader.Close()
 
 	scanner := bufio.NewScanner(reader)
+	scanner.Split(discard.LongLines(bufio.MaxScanTokenSize))
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		// Check if the start of this line contains a package name

--- a/annotator/osduplicate/dpkg/aptcache.go
+++ b/annotator/osduplicate/dpkg/aptcache.go
@@ -16,6 +16,7 @@ package dpkg
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"io"
@@ -103,9 +104,8 @@ func parseAptList(fileSystem iofs.FS, path string, cache *aptCache) error {
 	}
 	defer reader.Close()
 
-	// Replace Scanner with Reader
 	bufReader := bufio.NewReader(reader)
-
+	skippingLongLine := false
 	for {
 		line, isPrefix, err := bufReader.ReadLine()
 		if err != nil {
@@ -115,20 +115,21 @@ func parseAptList(fileSystem iofs.FS, path string, cache *aptCache) error {
 			return err
 		}
 
-		// Check if the start of this line contains a package name
-		if after, ok := strings.CutPrefix(string(line), "Package: "); ok {
-			cache.value[after] = struct{}{}
+		// if the line is too long to fit in the buffer skip it
+		if isPrefix {
+			skippingLongLine = true
+			continue
 		}
 
-		// If the line was too long for the buffer, drain the remainder of it.
-		for isPrefix {
-			_, isPrefix, err = bufReader.ReadLine()
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-				return err
-			}
+		// finish consuming the line (until the first isPrefix is false)
+		if skippingLongLine && !isPrefix {
+			skippingLongLine = false
+			continue
+		}
+
+		// Check if the start of this line contains a package name
+		if after, ok := bytes.CutPrefix(line, []byte("Package: ")); ok {
+			cache.value[string(after)] = struct{}{}
 		}
 	}
 

--- a/annotator/osduplicate/dpkg/dpkg.go
+++ b/annotator/osduplicate/dpkg/dpkg.go
@@ -100,7 +100,6 @@ func (a *Annotator) Annotate(ctx context.Context, input *annotator.ScanInput, re
 		pkgs := locationToPKGs[strings.TrimPrefix(filePath, "/")]
 
 		for _, pkg := range pkgs {
-
 			pkg.ExploitabilitySignals = append(pkg.ExploitabilitySignals, &vex.PackageExploitabilitySignal{
 				Plugin: Name,
 				// TODO(b/425890695): This exclusion doesn't quite match the use case here: The component

--- a/annotator/osduplicate/dpkg/dpkg.go
+++ b/annotator/osduplicate/dpkg/dpkg.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/osv-scalibr/annotator"
@@ -87,15 +88,18 @@ func (a *Annotator) Annotate(ctx context.Context, input *annotator.ScanInput, re
 			break
 		}
 
+		// Do not add duplication annotation on packages which are from non-main repos
+		// since vuln matching can happen only on packages hosted on main repos
+		pkgName := trimExtension(it.Name())
+		if !isAptCacheEmpty && !aptCache.isFromMainOSRepo(pkgName) {
+			it.Skip()
+			continue
+		}
+
 		// Remove leading '/' since SCALIBR fs paths don't include that.
 		pkgs := locationToPKGs[strings.TrimPrefix(filePath, "/")]
 
 		for _, pkg := range pkgs {
-			// Do not add duplication annotation on packages which are from non-main repos
-			// since vuln matching can happen only on packages hosted on main repos
-			if !isAptCacheEmpty && !aptCache.isFromMainOSRepo(pkg) {
-				continue
-			}
 
 			pkg.ExploitabilitySignals = append(pkg.ExploitabilitySignals, &vex.PackageExploitabilitySignal{
 				Plugin: Name,
@@ -109,4 +113,8 @@ func (a *Annotator) Annotate(ctx context.Context, input *annotator.ScanInput, re
 	}
 
 	return errors.Join(errs...)
+}
+
+func trimExtension(filename string) string {
+	return strings.TrimSuffix(filename, filepath.Ext(filename))
 }

--- a/annotator/osduplicate/dpkg/dpkg_test.go
+++ b/annotator/osduplicate/dpkg/dpkg_test.go
@@ -139,22 +139,22 @@ Package: curl
 		{
 			desc: "some_pkgs_found_in_info_and_in_main_repo",
 			txt: `
--- var/lib/dpkg/info/some.list --
+-- var/lib/dpkg/info/dpkg-pkg-name.list --
 /some/path
 /path/to/file-in-info
 /some/other/path
 -- var/lib/apt/lists/ports.ubuntu.com_ubuntu_dists_noble-updates_main_binary-arm64_Packages --
-Package: file-in-info
+Package: dpkg-pkg-name
 `,
 			packages: []*extractor.Package{
 				{
-					Name:     "file-in-info",
+					Name:     "launguage-pkg",
 					Location: extractor.LocationFromPath("path/to/file-in-info"),
 				},
 			},
 			wantPackages: []*extractor.Package{
 				{
-					Name:     "file-in-info",
+					Name:     "launguage-pkg",
 					Location: extractor.LocationFromPath("path/to/file-in-info"),
 					ExploitabilitySignals: []*vex.PackageExploitabilitySignal{{
 						Plugin:          dpkg.Name,

--- a/common/io/discard/discard.go
+++ b/common/io/discard/discard.go
@@ -1,0 +1,33 @@
+package discard
+
+import (
+	"bufio"
+	"slices"
+)
+
+// LongLines returns a bufio.SplitFunc that discards lines exceeding maxLineSize.
+func LongLines(maxLineSize int) bufio.SplitFunc {
+	isSkipping := false
+
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if isSkipping {
+			if crIdx := slices.Index(data, '\n'); crIdx != -1 {
+				// if newline is found stop skipping
+				isSkipping = false
+				return crIdx + 1, nil, nil
+			}
+			// keep skipping
+			return len(data), nil, nil
+		}
+
+		advance, token, err = bufio.ScanLines(data, atEOF)
+
+		// If buffer is full and no newline was found, trigger skip mode
+		if advance == 0 && token == nil && err == nil && len(data) >= maxLineSize {
+			isSkipping = true
+			return len(data), nil, nil
+		}
+
+		return advance, token, err
+	}
+}

--- a/common/io/discard/discard.go
+++ b/common/io/discard/discard.go
@@ -1,3 +1,18 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package discard contains logic to handle large input files
 package discard
 
 import (

--- a/common/io/discard/discard_test.go
+++ b/common/io/discard/discard_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package discard_test
 
 import (

--- a/common/io/discard/discard_test.go
+++ b/common/io/discard/discard_test.go
@@ -1,0 +1,93 @@
+package discard_test
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scalibr/common/io/discard"
+)
+
+func TestLongLines(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		maxLineSize int
+		exp         []string
+	}{
+		{
+			name:        "all_short_lines_are_kept",
+			input:       "foo\nbar\nbaz\n",
+			maxLineSize: 10,
+			exp:         []string{"foo", "bar", "baz"},
+		},
+		{
+			name:        "discard_single_long_line",
+			input:       "ok\nthislineistoolong\nok_again\n",
+			maxLineSize: 10,
+			exp:         []string{"ok", "ok_again"},
+		},
+		{
+			name:        "discard_multiple_long_lines",
+			input:       "a\nloooong\nb\nevenlooonger\nc\n",
+			maxLineSize: 5,
+			exp:         []string{"a", "b", "c"},
+		},
+		{
+			name:        "long_line_at_EOF",
+			input:       "keep\ndiscarded_at_eof",
+			maxLineSize: 6,
+			exp:         []string{"keep"},
+		},
+		{
+			name:        "exact_size_limit_boundary",
+			input:       "12\n1234\n12345\n123\n",
+			maxLineSize: 5,
+			exp:         []string{"12", "1234", "123"},
+		},
+		{
+			name:        "very_long_line_spanning_multiple_buffer_sizes",
+			input:       "a\n" + strings.Repeat("x", 20) + "\nb\n",
+			maxLineSize: 5,
+			exp:         []string{"a", "b"},
+		},
+		{
+			name:        "empty_lines_are_kept",
+			input:       "\n\na\n\n",
+			maxLineSize: 5,
+			exp:         []string{"", "", "a", ""},
+		},
+		{
+			name:        "empty_input",
+			input:       "",
+			maxLineSize: 5,
+			exp:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := bufio.NewScanner(strings.NewReader(tt.input))
+
+			// modify bufio.Scanner maxSize to keep the input size reasonable
+			buf := make([]byte, tt.maxLineSize)
+			scanner.Buffer(buf, tt.maxLineSize)
+
+			scanner.Split(discard.LongLines(tt.maxLineSize))
+
+			var got []string
+			for scanner.Scan() {
+				got = append(got, scanner.Text())
+			}
+
+			if err := scanner.Err(); err != nil {
+				t.Fatalf("unexpected scanner error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.exp, got); diff != "" {
+				t.Errorf("LongLines() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/common/linux/dpkg/dpkg.go
+++ b/common/linux/dpkg/dpkg.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/fs"
 	"path"
+	"path/filepath"
 
 	scalibrfs "github.com/google/osv-scalibr/fs"
 	"github.com/google/osv-scalibr/fs/diriterate"
@@ -32,13 +33,27 @@ const (
 	infoDirPath = "var/lib/dpkg/info"
 )
 
+// dpkgFileInfo groups the state of the file currently being processed.
+type dpkgFileInfo struct {
+	listPath string
+	reader   io.ReadCloser
+	scanner  *bufio.Scanner
+}
+
+// close cleanly shuts down the active file.
+func (f *dpkgFileInfo) close() error {
+	if f.reader != nil {
+		return f.reader.Close()
+	}
+	return nil
+}
+
 // filePathIterator is an iterator over all paths found in dpkg files with a specific extension.
 type filePathIterator struct {
-	rootFs            scalibrfs.FS
-	dirs              *diriterate.DirIterator
-	currentFileReader io.ReadCloser
-	currentScanner    *bufio.Scanner
-	fileExt           string
+	rootFs  scalibrfs.FS
+	dirs    *diriterate.DirIterator
+	fileExt string
+	current *dpkgFileInfo
 }
 
 func newFilePathIterator(rootFs scalibrfs.FS, fileExt string) (*filePathIterator, error) {
@@ -65,13 +80,13 @@ func (it *filePathIterator) Next(ctx context.Context) (string, error) {
 	}
 
 	for {
-		if it.currentScanner != nil && it.currentScanner.Scan() {
-			return it.currentScanner.Text(), nil
+		if it.current != nil && it.current.scanner.Scan() {
+			return it.current.scanner.Text(), nil
 		}
-		if it.currentFileReader != nil {
-			it.currentFileReader.Close()
-			it.currentFileReader = nil
-			it.currentScanner = nil
+
+		if it.current != nil {
+			it.current.close()
+			it.current = nil
 		}
 
 		listPath, err := it.nextFileWithExt()
@@ -83,8 +98,28 @@ func (it *filePathIterator) Next(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		it.currentFileReader = reader
-		it.currentScanner = bufio.NewScanner(reader)
+
+		it.current = &dpkgFileInfo{
+			listPath: listPath,
+			reader:   reader,
+			scanner:  bufio.NewScanner(reader),
+		}
+	}
+}
+
+// Name returns the path of the dpkg info file currently being processed.
+func (it *filePathIterator) Name() string {
+	if it.current != nil {
+		return filepath.Base(it.current.listPath)
+	}
+	return ""
+}
+
+// Skip skips the current dpkg info file.
+func (it *filePathIterator) Skip() {
+	if it.current != nil {
+		it.current.close()
+		it.current = nil
 	}
 }
 
@@ -107,8 +142,9 @@ func (it *filePathIterator) nextFileWithExt() (string, error) {
 // Close closes the iterator and releases any resources.
 func (it *filePathIterator) Close() error {
 	var errs []error
-	if it.currentFileReader != nil {
-		if err := it.currentFileReader.Close(); err != nil {
+
+	if it.current != nil {
+		if err := it.current.close(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/extractor/filesystem/os/apk/apkutil/apkutil.go
+++ b/extractor/filesystem/os/apk/apkutil/apkutil.go
@@ -47,6 +47,7 @@ func NewScanner(r io.Reader) *Scanner {
 	}
 }
 
+// DiscardLongLines makes the scanner discard long lines
 func (s *Scanner) DiscardLongLines() {
 	s.scanner.Split(discard.LongLines(bufio.MaxScanTokenSize))
 }

--- a/extractor/filesystem/os/apk/apkutil/apkutil.go
+++ b/extractor/filesystem/os/apk/apkutil/apkutil.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/google/osv-scalibr/common/io/discard"
 )
 
 // KeyValue represents a key-value pair from an APK record.
@@ -43,6 +45,10 @@ func NewScanner(r io.Reader) *Scanner {
 	return &Scanner{
 		scanner: bufio.NewScanner(r),
 	}
+}
+
+func (s *Scanner) DiscardLongLines() {
+	s.scanner.Split(discard.LongLines(bufio.MaxScanTokenSize))
 }
 
 // Scan reads from the scanner a single APK record.


### PR DESCRIPTION
Fixed bugs:

- [x] bufio.NewScanner fails on line bigger then the internal buffer
- [x] Package names should be taken from the package manager indexes, not other scalibr extractors

Reference:
- https://github.com/google/security-testbeds/pull/203